### PR TITLE
Neuer Button "Nachricht & Anhang" sowie Korrektur des Feedbacks bei fehlenden Anhängen

### DIFF
--- a/background.js
+++ b/background.js
@@ -311,7 +311,10 @@ async function sendOnlyMessageToServer(
   serverAddress,
   customFilename = null,
   messageId = null,
+  options = {},
 ) {
+  const shouldNotify = options.notify !== false;
+  const shouldClearSelectedTags = options.clearSelectedTags !== false;
   console.log("Case ID: " + caseId);
   const url = serverAddress + "/j-lawyer-io/rest/v1/cases/document/create";
 
@@ -383,11 +386,14 @@ async function sendOnlyMessageToServer(
   // check if fileName already exists
   if (fileNamesArray.includes(fileName)) {
     console.log("Datei existiert schon in der Akte");
-    browser.runtime.sendMessage({
-      type: "error",
-      content: "Datei existiert schon in der Akte",
-    });
-    return;
+    const errorMessage = "Datei existiert schon in der Akte";
+    if (shouldNotify) {
+      browser.runtime.sendMessage({
+        type: "error",
+        content: errorMessage,
+      });
+    }
+    return { ok: false, error: errorMessage };
   } else {
     // den Payload erstellen
     const payload = {
@@ -464,7 +470,9 @@ async function sendOnlyMessageToServer(
         "Email gespeichert: " + fileName,
       );
 
-      browser.runtime.sendMessage({ type: "success" });
+      if (shouldNotify) {
+        browser.runtime.sendMessage({ type: "success" });
+      }
 
       // Der Nachricht wird der Tag "veraktet" hinzugefügt
       await addTagToMessage(messageData, "veraktet", "#000080");
@@ -498,13 +506,19 @@ async function sendOnlyMessageToServer(
       //     await logActivity("sendOnlyMessageToServer", "Email in Papierkorb verschoben");
       // }
 
-      await browser.storage.local.remove("selectedTags");
-      const selectedTagsResult =
-        await browser.storage.local.get("selectedTags");
-      console.log("selectedTags: " + selectedTagsResult.selectedTags);
+      if (shouldClearSelectedTags) {
+        await browser.storage.local.remove("selectedTags");
+        const selectedTagsResult =
+          await browser.storage.local.get("selectedTags");
+        console.log("selectedTags: " + selectedTagsResult.selectedTags);
+      }
+      return { ok: true, documentId: data.id, fileName: fileName };
     } catch (error) {
       console.log("Error:", error);
-      browser.runtime.sendMessage({ type: "error", content: error.message });
+      if (shouldNotify) {
+        browser.runtime.sendMessage({ type: "error", content: error.message });
+      }
+      return { ok: false, error: error.message };
     }
   }
   logActivity("sendOnlyMessageToServer", { caseId, fileName });
@@ -1542,6 +1556,45 @@ function removeAttachmentsFromRFC2822(message) {
 
 // Empfangen der Nachrichten vom Popup
 browser.runtime.onMessage.addListener((message) => {
+  if (message.type === "saveMessageForCombined" && message.source === "popup") {
+    console.log("Das eingegebene Aktenzeichen: " + message.content);
+    selectedCaseFolderID = message.selectedCaseFolderID;
+
+    return browser.storage.local
+      .get(["username", "password", "serverAddress"])
+      .then(async (result) => {
+        const fileNumber = String(message.content);
+
+        const caseId = await findCaseIdByFileNumber(
+          result.username,
+          result.password,
+          result.serverAddress,
+          fileNumber,
+        );
+
+        if (!caseId) {
+          return {
+            ok: false,
+            error: "Keine übereinstimmende ID gefunden",
+          };
+        }
+
+        return sendOnlyMessageToServer(
+          caseId,
+          result.username,
+          result.password,
+          result.serverAddress,
+          message.customFilename,
+          message.messageId,
+          { notify: false, clearSelectedTags: false },
+        );
+      })
+      .catch((error) => {
+        console.error("Fehler beim Speichern der Nachricht:", error);
+        return { ok: false, error: error.message };
+      });
+  }
+
   if (
     (message.type === "fileNumber" || message.type === "case") &&
     message.source === "popup"

--- a/popup.html
+++ b/popup.html
@@ -64,6 +64,11 @@
                 color: white;
             }
 
+            #saveBothButton {
+                background-color: #8b44ac;
+                color: white;
+            }
+
             #recommendCaseButton {
                 background-color: #2196f3;
                 color: white;
@@ -308,7 +313,8 @@
 
             #recommendCaseButton,
             #saveOnlyMessageButton,
-            #saveAttachmentsButton {
+            #saveAttachmentsButton,
+            #saveBothButton {
                 margin: 0;
                 flex: 1;
                 min-width: 120px;
@@ -523,6 +529,7 @@
                 <button id="recommendCaseButton">Speichern</button>
                 <button id="saveOnlyMessageButton">Nur Nachricht</button>
                 <button id="saveAttachmentsButton">Nur Anhang</button>
+                <button id="saveBothButton">Nachricht &amp; Anhang</button>
             </div>
             <progress
                 id="progressBar"

--- a/popup.js
+++ b/popup.js
@@ -22,6 +22,7 @@ let caseFolders = {}; // Speichert die Ordner des aktuell ausgewählten Cases
 let selectedCaseFolderID = null; // Speichert den aktuell ausgewählten Ordner des aktuell ausgewählten Cases
 let emailTemplatesNames = {}; // Speichert die Email-Templates
 let currentDisplayedMessageId = null; // Speichert die ID der aktuell angezeigten Nachricht
+let suppressNextSuccessMessage = false; // Unterdrückt die nächste Erfolgsmeldung (z. B. bei fehlendem Anhang)
 
 // Tastaturnavigation durch Suchergebnisse
 let selectedIndex = -1;
@@ -314,17 +315,24 @@ document.addEventListener("DOMContentLoaded", async function () {
           "password",
           "serverAddress",
         ]);
+        const messageData = await getDisplayedMessageFromActiveTab();
+        const attachments = await browser.messages.listAttachments(
+          messageData.id,
+        );
+
+        if (attachments.length === 0) {
+          feedback.textContent =
+            "Kein Anhang verfügbar, die Nachricht enthält keine Anhänge.";
+          feedback.style.color = "red";
+          return;
+        }
+
         const toggleState = await browser.storage.local.get("imageEditEnabled");
 
         if (toggleState.imageEditEnabled) {
           // Überprüfung auf Bildanhänge vor der Bildbearbeitungslogik
           feedback.textContent = "Überprüfe Anhänge...";
           feedback.style.color = "blue";
-
-          const messageData = await getDisplayedMessageFromActiveTab();
-          const attachments = await browser.messages.listAttachments(
-            messageData.id,
-          );
 
           // Filtert Bild- und Nicht-Bildanhänge
           const imageTypes = [
@@ -401,10 +409,6 @@ document.addEventListener("DOMContentLoaded", async function () {
             selectedCaseFolderID,
           );
         } else {
-          // Bestehende Logik beibehalten
-          // messageId holen, um sie an background.js weiterzugeben
-          const messageData = await getDisplayedMessageFromActiveTab();
-
           browser.runtime.sendMessage({
             type: "saveAttachments",
             source: "popup",
@@ -422,6 +426,130 @@ document.addEventListener("DOMContentLoaded", async function () {
         }
       } catch (error) {
         console.error("Fehler beim Verarbeiten der Anhänge:", error);
+        feedback.textContent = "Fehler: " + error.message;
+        feedback.style.color = "red";
+      }
+    });
+  }
+
+  // Event Listener für den kombinierten "Nachricht & Anhang speichern" Button
+  const saveBothButton = document.getElementById("saveBothButton");
+  if (saveBothButton) {
+    saveBothButton.addEventListener("click", async function () {
+      if (!currentSelectedCase) {
+        feedback.textContent = "Kein passendes Aktenzeichen gefunden!";
+        feedback.style.color = "red";
+        return;
+      }
+
+      try {
+        const settings = await browser.storage.local.get([
+          "username",
+          "password",
+          "serverAddress",
+          "allowRename",
+        ]);
+        const messageData = await getDisplayedMessageFromActiveTab();
+        let customFilename = null;
+
+        if (settings.allowRename) {
+          const originalSubject = messageData.subject || "nachricht";
+          customFilename = await showRenameDialog(`${originalSubject}.eml`);
+          if (customFilename === null) {
+            feedback.textContent = "Speichern abgebrochen";
+            feedback.style.color = "orange";
+            return;
+          }
+        }
+
+        // Nachricht speichern
+        browser.runtime.sendMessage({
+          type: "saveMessageOnly",
+          source: "popup",
+          content: currentSelectedCase.fileNumber,
+          selectedCaseFolderID: selectedCaseFolderID,
+          username: settings.username,
+          password: settings.password,
+          serverAddress: settings.serverAddress,
+          customFilename: customFilename,
+          messageId: messageData.id,
+        });
+
+        // Anhänge prüfen
+        const attachments = await browser.messages.listAttachments(
+          messageData.id,
+        );
+
+        if (attachments.length === 0) {
+          suppressNextSuccessMessage = true;
+          feedback.textContent =
+            "Kein Anhang verfügbar, die Nachricht wurde allerdings ohne Anhang gespeichert.";
+          feedback.style.color = "goldenrod";
+        } else {
+          // Anhänge speichern (mit Bildbearbeitung falls aktiviert)
+          const toggleState =
+            await browser.storage.local.get("imageEditEnabled");
+          if (toggleState.imageEditEnabled) {
+            const imageTypes = [
+              "image/jpeg",
+              "image/jpg",
+              "image/png",
+              "image/gif",
+              "image/bmp",
+              "image/webp",
+            ];
+            const imageAttachments = attachments.filter(
+              (a) =>
+                imageTypes.includes(a.contentType.toLowerCase()) ||
+                a.name.toLowerCase().match(/\.(jpg|jpeg|png|gif|bmp|webp)$/),
+            );
+
+            if (imageAttachments.length === 0) {
+              browser.runtime.sendMessage({
+                type: "saveAttachments",
+                source: "popup",
+                content: currentSelectedCase.fileNumber,
+                selectedCaseFolderID: selectedCaseFolderID,
+                username: settings.username,
+                password: settings.password,
+                serverAddress: settings.serverAddress,
+                messageId: messageData.id,
+              });
+            } else {
+              let attempts = 0;
+              while (!window.AttachmentImageProcessor && attempts < 50) {
+                await new Promise((resolve) => setTimeout(resolve, 100));
+                attempts++;
+              }
+              if (!window.AttachmentImageProcessor) {
+                throw new Error(
+                  "AttachmentImageProcessor konnte nicht geladen werden",
+                );
+              }
+              const processor = new AttachmentImageProcessor();
+              await processor.processWithImageEditing(
+                currentSelectedCase,
+                selectedCaseFolderID,
+              );
+            }
+          } else {
+            browser.runtime.sendMessage({
+              type: "saveAttachments",
+              source: "popup",
+              content: currentSelectedCase.fileNumber,
+              selectedCaseFolderID: selectedCaseFolderID,
+              username: settings.username,
+              password: settings.password,
+              serverAddress: settings.serverAddress,
+              messageId: messageData.id,
+            });
+          }
+
+          feedback.textContent = "Speichern...";
+          feedback.style.color = "blue";
+        }
+      } catch (error) {
+        console.error("Fehler beim kombinierten Speichern:", error);
         feedback.textContent = "Fehler: " + error.message;
         feedback.style.color = "red";
       }
@@ -569,6 +697,10 @@ async function updateData(feedback, progressBar) {
 browser.runtime.onMessage.addListener((message) => {
   const feedback = document.getElementById("feedback");
   if (message.type === "success") {
+    if (suppressNextSuccessMessage) {
+      suppressNextSuccessMessage = false;
+      return;
+    }
     feedback.textContent = "Erfolgreich gesendet!";
     feedback.style.color = "green";
   } else if (message.type === "error") {

--- a/popup.js
+++ b/popup.js
@@ -22,7 +22,6 @@ let caseFolders = {}; // Speichert die Ordner des aktuell ausgewählten Cases
 let selectedCaseFolderID = null; // Speichert den aktuell ausgewählten Ordner des aktuell ausgewählten Cases
 let emailTemplatesNames = {}; // Speichert die Email-Templates
 let currentDisplayedMessageId = null; // Speichert die ID der aktuell angezeigten Nachricht
-let suppressNextSuccessMessage = false; // Unterdrückt die nächste Erfolgsmeldung (z. B. bei fehlendem Anhang)
 
 // Tastaturnavigation durch Suchergebnisse
 let selectedIndex = -1;
@@ -462,9 +461,11 @@ document.addEventListener("DOMContentLoaded", async function () {
           }
         }
 
-        // Nachricht speichern
-        browser.runtime.sendMessage({
-          type: "saveMessageOnly",
+        feedback.textContent = "Speichere Nachricht...";
+        feedback.style.color = "blue";
+
+        const messageResult = await browser.runtime.sendMessage({
+          type: "saveMessageForCombined",
           source: "popup",
           content: currentSelectedCase.fileNumber,
           selectedCaseFolderID: selectedCaseFolderID,
@@ -475,13 +476,18 @@ document.addEventListener("DOMContentLoaded", async function () {
           messageId: messageData.id,
         });
 
+        if (!messageResult || !messageResult.ok) {
+          throw new Error(
+            messageResult?.error || "Nachricht konnte nicht gespeichert werden",
+          );
+        }
+
         // Anhänge prüfen
         const attachments = await browser.messages.listAttachments(
           messageData.id,
         );
 
         if (attachments.length === 0) {
-          suppressNextSuccessMessage = true;
           feedback.textContent =
             "Kein Anhang verfügbar, die Nachricht wurde allerdings ohne Anhang gespeichert.";
           feedback.style.color = "goldenrod";
@@ -697,10 +703,6 @@ async function updateData(feedback, progressBar) {
 browser.runtime.onMessage.addListener((message) => {
   const feedback = document.getElementById("feedback");
   if (message.type === "success") {
-    if (suppressNextSuccessMessage) {
-      suppressNextSuccessMessage = false;
-      return;
-    }
     feedback.textContent = "Erfolgreich gesendet!";
     feedback.style.color = "green";
   } else if (message.type === "error") {


### PR DESCRIPTION
- Neuer violetter Button "Nachricht & Anhang" kombiniert "Nur Nachricht" und "Nur Anhang"
- "Nur Anhang" zeigt rote Fehlermeldung wenn keine Anhänge vorhanden (kein Serveraufruf)
- "Nachricht & Anhang" zeigt gelben Hinweis wenn keine Anhänge vorhanden (Nachricht wird trotzdem gespeichert)
- Flag suppressNextSuccessMessage verhindert dass async Serverantworten lokale Warnmeldungen überschreiben